### PR TITLE
circle ci: add megacheck job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,25 @@ jobs:
           paths:
               - /tmp/go/cache
 
+  megacheck:
+    <<: *defaults
+    steps:
+      - restore_cache:
+          keys:
+              - megacheck-cache-{{ .Branch }}-{{ .Environment.CIRCLE_PREVIOUS_BUILD_NUM }}
+              - megacheck-cache-{{ .Branch }}-
+              - megacheck-cache-
+          paths:
+              - /tmp/go/cache
+      - attach_workspace:
+          at: .
+      - run: go get -u honnef.co/go/tools/cmd/megacheck
+      - run: megacheck ./...
+      - save_cache:
+          key: megacheck-cache-{{ .Branch }}-{{ .Environment.CIRCLE_BUILD_NUM }}
+          paths:
+              - /tmp/go/cache
+
   release-master:
     <<: *defaults
     steps:
@@ -192,6 +211,9 @@ workflows:
       - race:
           requires:
             - prepare
+      - megacheck:
+          requires:
+            - prepare
 
       - release-master:
           filters:
@@ -202,6 +224,7 @@ workflows:
             - test
             - test-fuse
             - race
+            - megacheck
 
       - approve-docker:
           type: approval
@@ -217,6 +240,7 @@ workflows:
             - build
             - test-fuse
             - race
+            - megacheck
 
       - docker:
           requires:


### PR DESCRIPTION
This PR adds a [`megacheck`](https://github.com/dominikh/go-tools/tree/master/cmd/megacheck) job, which is relatively quick, but we'd need to clean up a lot of existing errors if we wanted to actually include it.
![screenshot from 2018-05-09 13-17-02](https://user-images.githubusercontent.com/1194128/39831845-4b81fcea-538b-11e8-973e-335cac9ca388.png)

<details>
<summary>Output (updated 10/30/2018)</summary>

```
accounts/abi/bind/backends/simulated.go:83:42: event.TypeMux is deprecated: use Feed  (SA1019)
accounts/abi/bind/backends/simulated.go:418:38: event.TypeMux is deprecated: use Feed  (SA1019)
bmt/bmt.go:201:16: this result of append is never used, except maybe in other appends (SA4010)
bmt/bmt.go:396:3: this value of n is never used (SA4006)
cmd/gochain/chaincmd.go:307:46: event.TypeMux is deprecated: use Feed  (SA1019)
cmd/gochain/main.go:231:14: stackdriver.NewExporter is deprecated: This package has been moved to: contrib.go.opencensus.io/exporter/stackdriver.  (SA1019)
cmd/gochain/main.go:231:38: stackdriver.Options is deprecated: This package has been moved to: contrib.go.opencensus.io/exporter/stackdriver.  (SA1019)
cmd/swarm/config.go:145:4: this value of err is never used (SA4006)
cmd/swarm/config.go:145:20: New is a pure function but its return value is ignored (SA4017)
compression/rle/read_write.go:27:1: only the first constant has an explicit type (SA9004)
consensus/clique/clique.go:296:2: this value of ctx is never used (SA4006)
core/block_validator.go:87:2: this value of ctx is never used (SA4006)
core/blockchain.go:1383:2: this value of ctx is never used (SA4006)
core/blockchain.go:1505:2: this value of ctx is never used (SA4006)
core/blockchain_test.go:627:13: this value of err is never used (SA4006)
core/blockchain_test.go:636:13: this value of err is never used (SA4006)
core/blockchain_test.go:1094:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
core/blockchain_test.go:1094:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
core/blockchain_test.go:1094:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
core/helper_test.go:31:12: event.TypeMux is deprecated: use Feed  (SA1019)
core/helper_test.go:67:36: event.TypeMux is deprecated: use Feed  (SA1019)
core/helper_test.go:83:29: event.TypeMux is deprecated: use Feed  (SA1019)
core/state/statedb.go:524:2: this value of ctx is never used (SA4006)
core/tx_pool.go:665:2: this value of ctx is never used (SA4006)
core/tx_pool.go:682:2: this value of ctx is never used (SA4006)
core/tx_pool.go:702:2: this value of ctx is never used (SA4006)
core/tx_pool.go:716:2: this value of ctx is never used (SA4006)
core/tx_pool.go:960:2: this value of ctx is never used (SA4006)
core/tx_pool.go:1333:2: this value of ctx is never used (SA4006)
core/tx_pool.go:1456:2: this value of ctx is never used (SA4006)
core/types/derive_sha.go:36:2: this value of ctx is never used (SA4006)
crypto/bn256/cloudflare/optate.go:202:11: this value of newR is never used (SA4006)
crypto/bn256/cloudflare/optate.go:204:2: this value of r is never used (SA4006)
eth/api_backend.go:150:2: this value of ctx is never used (SA4006)
eth/api_backend.go:251:37: event.TypeMux is deprecated: use Feed  (SA1019)
eth/backend.go:76:18: event.TypeMux is deprecated: use Feed  (SA1019)
eth/backend.go:416:32: event.TypeMux is deprecated: use Feed  (SA1019)
eth/downloader/api.go:32:29: event.TypeMux is deprecated: use Feed  (SA1019)
eth/downloader/api.go:41:47: event.TypeMux is deprecated: use Feed  (SA1019)
eth/downloader/downloader.go:102:8: event.TypeMux is deprecated: use Feed  (SA1019)
eth/downloader/downloader.go:206:55: event.TypeMux is deprecated: use Feed  (SA1019)
eth/downloader/downloader_test.go:100:56: event.TypeMux is deprecated: use Feed  (SA1019)
eth/filters/api.go:55:13: event.TypeMux is deprecated: use Feed  (SA1019)
eth/filters/bench_test.go:126:13: event.TypeMux is deprecated: use Feed  (SA1019)
eth/filters/bench_test.go:197:13: event.TypeMux is deprecated: use Feed  (SA1019)
eth/filters/filter.go:33:14: event.TypeMux is deprecated: use Feed  (SA1019)
eth/filters/filter_system.go:91:13: event.TypeMux is deprecated: use Feed  (SA1019)
eth/filters/filter_system.go:114:26: event.TypeMux is deprecated: use Feed  (SA1019)
eth/filters/filter_system_test.go:42:14: event.TypeMux is deprecated: use Feed  (SA1019)
eth/filters/filter_system_test.go:55:35: event.TypeMux is deprecated: use Feed  (SA1019)
eth/filters/filter_system_test.go:164:21: event.TypeMux is deprecated: use Feed  (SA1019)
eth/filters/filter_system_test.go:217:17: event.TypeMux is deprecated: use Feed  (SA1019)
eth/filters/filter_system_test.go:273:17: event.TypeMux is deprecated: use Feed  (SA1019)
eth/filters/filter_system_test.go:318:17: event.TypeMux is deprecated: use Feed  (SA1019)
eth/filters/filter_system_test.go:344:17: event.TypeMux is deprecated: use Feed  (SA1019)
eth/filters/filter_system_test.go:460:17: event.TypeMux is deprecated: use Feed  (SA1019)
eth/filters/filter_test.go:56:17: event.TypeMux is deprecated: use Feed  (SA1019)
eth/filters/filter_test.go:115:17: event.TypeMux is deprecated: use Feed  (SA1019)
eth/handler.go:82:17: event.TypeMux is deprecated: use Feed  (SA1019)
eth/handler.go:99:123: event.TypeMux is deprecated: use Feed  (SA1019)
eth/handler.go:163:3: this value of ctx is never used (SA4006)
eth/helper_test.go:56:16: event.TypeMux is deprecated: use Feed  (SA1019)
eth/peer.go:610:2: this value of ctx is never used (SA4006)
eth/peer.go:632:2: this value of ctx is never used (SA4006)
eth/peer.go:664:2: this value of ctx is never used (SA4006)
eth/sync.go:50:45: argument ctx is overwritten before first use (SA4009)
ethdb/segment_set_test.go:63:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
ethdb/segment_set_test.go:63:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
event/feed.go:145:2: this value of ctx is never used (SA4006)
internal/ethapi/backend.go:44:14: event.TypeMux is deprecated: use Feed  (SA1019)
les/api_backend.go:218:37: event.TypeMux is deprecated: use Feed  (SA1019)
les/backend.go:74:18: event.TypeMux is deprecated: use Feed  (SA1019)
les/backend.go:232:36: event.TypeMux is deprecated: use Feed  (SA1019)
les/handler.go:120:12: event.TypeMux is deprecated: use Feed  (SA1019)
les/handler.go:134:143: event.TypeMux is deprecated: use Feed  (SA1019)
les/helper_test.go:140:16: event.TypeMux is deprecated: use Feed  (SA1019)
log/handler_glog.go:209:25: r.Call.PC is deprecated: Use Call.Frame instead.  (SA1019)
log/handler_glog.go:217:17: r.Call.PC is deprecated: Use Call.Frame instead.  (SA1019)
log/handler_glog.go:223:16: r.Call.PC is deprecated: Use Call.Frame instead.  (SA1019)
metrics/registry_test.go:273:2: this value of err is never used (SA4006)
metrics/registry_test.go:280:3: empty branch (SA9003)
metrics/registry_test.go:280:3: empty branch (SA9003)
metrics/registry_test.go:296:2: this value of err is never used (SA4006)
miner/miner.go:47:12: event.TypeMux is deprecated: use Feed  (SA1019)
miner/miner.go:58:56: event.TypeMux is deprecated: use Feed  (SA1019)
miner/miner.go:162:2: this value of ctx is never used (SA4006)
miner/worker.go:129:15: event.TypeMux is deprecated: use Feed  (SA1019)
miner/worker.go:170:87: event.TypeMux is deprecated: use Feed  (SA1019)
miner/worker_test.go:131:51: event.TypeMux is deprecated: use Feed  (SA1019)
miner/worker_test.go:157:2: this value of block is never used (SA4006)
netstats/netstats.go:474:2: this value of ctx is never used (SA4006)
netstats/netstats.go:569:2: this value of ctx is never used (SA4006)
netstats/netstats.go:736:2: this value of ctx is never used (SA4006)
node/node.go:43:12: event.TypeMux is deprecated: use Feed  (SA1019)
node/node.go:123:26: event.TypeMux is deprecated: use Feed  (SA1019)
node/node.go:577:28: event.TypeMux is deprecated: use Feed  (SA1019)
node/service.go:38:18: event.TypeMux is deprecated: use Feed  (SA1019)
p2p/discv5/net.go:657:2: empty branch (SA9003)
p2p/discv5/net.go:1235:5: unsigned values are never < 0 (SA4003)
p2p/message.go:244:2: this value of ctx is never used (SA4006)
p2p/netutil/net.go:215:37: use net.IP.Equal to compare net.IPs, not bytes.Equal (SA1021)
p2p/rlpx.go:333:59: argument token is overwritten before first use (SA4009)
p2p/rlpx.go:381:2: this value of ctx is never used (SA4006)
p2p/server.go:880:2: this value of ctx is never used (SA4006)
p2p/simulations/mocker_test.go:89:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
swarm/api/http/error_test.go:45:12: this value of err is never used (SA4006)
swarm/api/http/error_test.go:71:12: this value of err is never used (SA4006)
swarm/api/http/error_test.go:97:12: this value of err is never used (SA4006)
swarm/api/http/error_test.go:128:12: this value of err is never used (SA4006)
swarm/api/http/server.go:183:17: hdr.Xattrs is deprecated: Use PAXRecords instead.  (SA1019)
swarm/api/http/server.go:488:2: this value of err is never used (SA4006)
swarm/api/http/server_test.go:91:13: this value of err is never used (SA4006)
swarm/fuse/swarmfs_test.go:352:5: this value of err is never used (SA4006)
swarm/network/kademlia/kademlia.go:423:3: empty branch (SA9003)
build/ci.go:522:2: should use 'return <expr>' instead of 'if <expr> { return <bool> }; return <bool>' (S1008)
cmd/faucet/faucet.go:513:94: should use time.Until instead of t.Sub(time.Now()) (S1024)
ethdb/table.go:200:2: should replace loop with a = append(a, t.segments.Slice()...) (S1011)
accounts/abi/event_test.go:250:6: type testResult is unused (U1000)
accounts/abi/event_test.go:256:6: type testCase is unused (U1000)
accounts/usbwallet/ledger.go:57:2: const ledgerP1ConfirmFetchAddress is unused (U1000)
accounts/usbwallet/ledger.go:61:2: const ledgerP2ReturnAddressChainCode is unused (U1000)
bmt/bmt.go:82:2: field max is unused (U1000)
cmd/ethkey/main.go:56:2: var messageFlag is unused (U1000)
cmd/faucet/faucet.go:80:2: var githubUser is unused (U1000)
cmd/faucet/faucet.go:81:2: var githubToken is unused (U1000)
cmd/faucet/faucet.go:635:6: func authGitHub is unused (U1000)
cmd/gochain/main.go:54:2: var relOracle is unused (U1000)
cmd/puppeth/module.go:127:6: func resolve is unused (U1000)
consensus/clique/clique.go:89:2: var errMissingVanity is unused (U1000)
core/asm/compiler.go:268:2: var errExpBol is unused (U1000)
core/asm/compiler.go:269:2: var errExpElementOrLabel is unused (U1000)
core/blockchain.go:115:2: field checkpoint is unused (U1000)
core/blockchain.go:1621:23: func (*BlockChain).writeHeader is unused (U1000)
core/chain_makers.go:45:2: field uncles is unused (U1000)
core/helper_test.go:79:6: func NewTestManager is unused (U1000)
core/tx_pool.go:109:2: var underpricedTxCounter is unused (U1000)
core/types/transaction.go:37:2: var errNoSigner is unused (U1000)
core/vm/contracts_test.go:30:2: field gas is unused (U1000)
core/vm/logger_test.go:44:6: type dummyStateDB is unused (U1000)
core/vm/stack.go:45:18: func (*Stack).pushN is unused (U1000)
crypto/bn256/cloudflare/constants.go:29:5: var np is unused (U1000)
crypto/bn256/cloudflare/gfp_decl.go:13:5: var hasBMI2 is unused (U1000)
crypto/ecies/ecies_test.go:81:6: func cmpPublic is unused (U1000)
crypto/ecies/ecies_test.go:97:6: func cmpPrivate is unused (U1000)
eth/downloader/downloader_test.go:461:32: func (*downloadTesterPeer).setDelay is unused (U1000)
eth/filters/api.go:56:2: field quit is unused (U1000)
eth/peer.go:157:2: field forkDrop is unused (U1000)
ethdb/db.go:48:2: field mu is unused (U1000)
ethdb/file_segment.go:726:6: func hexdump is unused (U1000)
event/feed.go:54:2: field closed is unused (U1000)
les/bloombits.go:79:2: const bloomConfirms is unused (U1000)
les/bloombits.go:83:2: const bloomThrottling is unused (U1000)
les/handler.go:109:2: field lesTopic is unused (U1000)
les/serverpool.go:76:2: const pstatRecentAdjust is unused (U1000)
les/serverpool.go:88:2: const peerSelectMinWeight is unused (U1000)
les/sync.go:31:2: const minDesiredPeerCount is unused (U1000)
metrics/timer.go:80:2: field h is unused (U1000)
metrics/timer.go:81:2: field m is unused (U1000)
miner/worker_test.go:74:2: field testTxFeed is unused (U1000)
mobile/bind.go:37:6: type signer is unused (U1000)
p2p/discover/table_test.go:585:27: func (*preminedTestnet).mine is unused (U1000)
p2p/discover/udp.go:52:2: const sendTimeout is unused (U1000)
p2p/discover/udp.go:171:2: field nat is unused (U1000)
p2p/discv5/database.go:65:2: var nodeDBDiscoverLocalEndpoint is unused (U1000)
p2p/discv5/database.go:316:19: func (*nodeDB).localEndpoint is unused (U1000)
p2p/discv5/database.go:324:19: func (*nodeDB).updateLocalEndpoint is unused (U1000)
p2p/discv5/net.go:39:2: var errWrongAddress is unused (U1000)
p2p/discv5/net.go:84:2: field slowRevalidateQueue is unused (U1000)
p2p/discv5/net.go:85:2: field fastRevalidateQueue is unused (U1000)
p2p/discv5/net.go:88:2: field sendBuf is unused (U1000)
p2p/discv5/net.go:111:2: field nresults is unused (U1000)
p2p/discv5/net.go:833:2: const invalidEvent is unused (U1000)
p2p/discv5/net_test.go:268:28: func (*preminedTestnet).sendFindnode is unused (U1000)
p2p/discv5/net_test.go:319:28: func (*preminedTestnet).sendTopicQuery is unused (U1000)
p2p/discv5/net_test.go:339:27: func (*preminedTestnet).mine is unused (U1000)
p2p/discv5/node.go:69:16: func (*Node).setAddr is unused (U1000)
p2p/discv5/node.go:78:16: func (*Node).addrEqual is unused (U1000)
p2p/discv5/node.go:260:7: const nodeIDBits is unused (U1000)
p2p/discv5/node.go:329:18: func NodeID.mustPubkey is unused (U1000)
p2p/discv5/ntp.go:33:2: const ntpPool is unused (U1000)
p2p/discv5/ntp.go:34:2: const ntpChecks is unused (U1000)
p2p/discv5/ntp.go:39:6: type durationSlice is unused (U1000)
p2p/discv5/ntp.go:47:6: func checkClockDrift is unused (U1000)
p2p/discv5/ntp.go:72:6: func sntpDrift is unused (U1000)
p2p/discv5/sim_test.go:297:22: func (*simulation).dropNode is unused (U1000)
p2p/discv5/sim_test.go:361:25: func (*simTransport).sendPong is unused (U1000)
p2p/discv5/table.go:41:2: const maxBondingPingPongs is unused (U1000)
p2p/discv5/table_test.go:34:6: type nullTransport is unused (U1000)
p2p/discv5/table_test.go:145:6: func fillBucket is unused (U1000)
p2p/discv5/table_test.go:162:6: type pingRecorder is unused (U1000)
p2p/discv5/table_test.go:164:6: func newPingRecorder is unused (U1000)
p2p/discv5/ticket.go:36:2: const timeWindow is unused (U1000)
p2p/discv5/ticket.go:37:2: const wantTicketsInWindow is unused (U1000)
p2p/discv5/ticket.go:142:2: field nextTicketReg is unused (U1000)
p2p/discv5/ticket.go:272:23: func (*ticketStore).ticketsInWindow is unused (U1000)
p2p/discv5/ticket.go:289:23: func (*ticketStore).removeExcessTickets is unused (U1000)
p2p/discv5/ticket.go:300:6: type ticketRefByWaitTime is unused (U1000)
p2p/discv5/ticket.go:307:20: func ticketRef.waitTime is unused (U1000)
p2p/discv5/ticket.go:568:23: func (*ticketStore).getNodeTicket is unused (U1000)
p2p/discv5/ticket.go:773:23: func (*topicRadius).isInRadius is unused (U1000)
p2p/discv5/udp.go:41:2: var errExpired is unused (U1000)
p2p/discv5/udp.go:42:2: var errUnsolicitedReply is unused (U1000)
p2p/discv5/udp.go:43:2: var errUnknownNode is unused (U1000)
p2p/discv5/udp.go:44:2: var errTimeout is unused (U1000)
p2p/discv5/udp.go:45:2: var errClockWarp is unused (U1000)
p2p/discv5/udp.go:46:2: var errClosed is unused (U1000)
p2p/discv5/udp.go:52:2: const queryDelay is unused (U1000)
p2p/discv5/udp.go:55:2: const ntpFailureThreshold is unused (U1000)
p2p/discv5/udp.go:56:2: const ntpWarningCooldown is unused (U1000)
p2p/discv5/udp.go:57:2: const driftThreshold is unused (U1000)
p2p/discv5/udp.go:198:23: func rpcEndpoint.equal is unused (U1000)
p2p/discv5/udp.go:236:2: field nat is unused (U1000)
p2p/discv5/udp.go:284:15: func (*udp).sendFindnode is unused (U1000)
p2p/discv5/udp_test.go:41:2: var futureExp is unused (U1000)
p2p/discv5/udp_test.go:42:2: var testTarget is unused (U1000)
p2p/discv5/udp_test.go:43:2: var testRemote is unused (U1000)
p2p/discv5/udp_test.go:44:2: var testLocalAnnounced is unused (U1000)
p2p/discv5/udp_test.go:45:2: var testLocal is unused (U1000)
p2p/discv5/udp_test.go:394:6: type dgramPipe is unused (U1000)
p2p/discv5/udp_test.go:402:6: func newpipe is unused (U1000)
p2p/enr/enr.go:49:2: var errInvalidSigsize is unused (U1000)
p2p/peer.go:56:2: const getPeersMsg is unused (U1000)
p2p/peer.go:57:2: const peersMsg is unused (U1000)
p2p/rlpx.go:460:23: func (*authMsgV4).sealPlain is unused (U1000)
p2p/simulations/adapters/exec.go:136:2: field key is unused (U1000)
rlp/decode_test.go:699:3: field private is unused (U1000)
swarm/storage/dbstore.go:50:2: const kpData is unused (U1000)
swarm/storage/netstore.go:88:2: const requesterCount is unused (U1000)
tests/init_test.go:42:2: var difficultyTestDir is unused (U1000)
trie/database.go:748:21: func (*Database).verifyIntegrity is unused (U1000)
trie/database.go:770:21: func (*Database).accumulate is unused (U1000)
whisper/whisperv5/filter_test.go:39:6: func InitDebugTest is unused (U1000)
whisper/whisperv6/filter_test.go:39:6: func InitDebugTest is unused (U1000)
Exited with code 1
```
</details>
Some of these are easy and relevant, others are messier or in low priority packages. We can fix them incrementally in separate PRs, and rebase this branch to stay updated.