### PR TITLE
ci: update golang to 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.0
 defaults: &defaults
   working_directory: /go/src/github.com/gochain/gochain
   docker:
-    - image: circleci/golang:1.13
+    - image: circleci/golang:1.14
   environment: # apparently expansion doesn't work here yet: https://discuss.circleci.com/t/environment-variable-expansion-in-working-directory/11322
     - OS=linux
     - ARCH=amd64


### PR DESCRIPTION
Draft for visibility. Not ready to merge.

- [x] Waiting on CircleCI to add 1.14.1
- [ ] Waiting for 1.14.2 release
- [ ] Waiting on CircleCI to add 1.14.2