### PR TITLE
GIP 29&30: add Darvaza fork to burn gas fees and reconfigure gas price

### DIFF
--- a/core/genesis-test.json
+++ b/core/genesis-test.json
@@ -8,6 +8,7 @@
     "eip158Block": 0,
     "byzantiumBlock": 0,
     "constantinopleBlock": 4081350,
+    "darvazaBlock": 16811000,
     "darvazaDefaultGas": 2000000000000,
     "clique": {
       "period": 5,

--- a/core/genesis-test.json
+++ b/core/genesis-test.json
@@ -8,6 +8,7 @@
     "eip158Block": 0,
     "byzantiumBlock": 0,
     "constantinopleBlock": 4081350,
+    "darvazaDefaultGas": 2000000000000,
     "clique": {
       "period": 5,
       "epoch": 3000

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -222,9 +222,8 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 		}
 	}
 	st.refundGas()
-	fee := new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice)
 	if !st.evm.ChainConfig().IsDarvaza(st.evm.BlockNumber) {
-		st.state.AddBalance(st.evm.Coinbase, fee)
+		st.state.AddBalance(st.evm.Coinbase, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice))
 	}
 
 	return ret, st.gasUsed(), vmerr != nil, err

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -222,7 +222,10 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 		}
 	}
 	st.refundGas()
-	st.state.AddBalance(st.evm.Coinbase, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice))
+	fee := new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice)
+	if !st.evm.ChainConfig().IsDarvaza(st.evm.BlockNumber) {
+		st.state.AddBalance(st.evm.Coinbase, fee)
+	}
 
 	return ret, st.gasUsed(), vmerr != nil, err
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -82,7 +82,7 @@ type GoChain struct {
 	ApiBackend *EthApiBackend
 
 	miner     *miner.Miner
-	gasPrice  *big.Int
+	gasPrice  *big.Int // nil for default/dynamic
 	etherbase common.Address
 
 	networkId     uint64

--- a/eth/config.go
+++ b/eth/config.go
@@ -38,7 +38,7 @@ var DefaultConfig = Config{
 	TrieTimeout:   60 * time.Minute,
 	MinerGasFloor: params.TargetGasLimit,
 	MinerGasCeil:  params.TargetGasLimit,
-	MinerGasPrice: gasprice.Default,
+	MinerGasPrice: nil,
 	MinerRecommit: 1 * time.Second,
 
 	TxPool: core.DefaultTxPoolConfig,
@@ -78,7 +78,7 @@ type Config struct {
 	MinerExtraData []byte         `toml:",omitempty"`
 	MinerGasFloor  uint64
 	MinerGasCeil   uint64
-	MinerGasPrice  *big.Int
+	MinerGasPrice  *big.Int // nil for default/dynamic
 	MinerRecommit  time.Duration
 	MinerNoverify  bool
 

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -181,7 +181,7 @@ func (gpo *Oracle) minPrice(num *big.Int) *big.Int {
 	if gpo.defaultPrice != nil {
 		return gpo.defaultPrice
 	}
-	const blockOffset = 12 // look ~1 minute ahead, since we are suggesting gas for near-future txs
+	const blockOffset = 60 * 12 // look ~1 hour ahead, since we are suggesting gas for near-future txs
 	return DefaultFn(gpo.backend.ChainConfig())(new(big.Int).Add(big.NewInt(blockOffset), num))
 }
 

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -24,11 +24,9 @@ func TestOracle_SuggestPrice(t *testing.T) {
 				Blocks:     1,
 				Percentile: 60,
 			},
-			backend: newTestBackend(
-				block{
-					txs: []tx{{price: 1}},
-				},
-			),
+			backend: newTestBackend(nil, block{
+				txs: []tx{{price: 1}},
+			}),
 		},
 		{
 			name: "single",
@@ -37,13 +35,11 @@ func TestOracle_SuggestPrice(t *testing.T) {
 				Blocks:     1,
 				Percentile: 60,
 			},
-			backend: newTestBackend(
-				block{
-					txs: []tx{
-						{price: 1000},
-					},
+			backend: newTestBackend(nil, block{
+				txs: []tx{
+					{price: 1000},
 				},
-			),
+			}),
 		},
 		{
 			name: "single full",
@@ -51,15 +47,14 @@ func TestOracle_SuggestPrice(t *testing.T) {
 			params: Config{
 				Blocks:     1,
 				Percentile: 60,
+				Default:    bigInt(1),
 			},
-			backend: newTestBackend(
-				block{
-					full: true,
-					txs: []tx{
-						{price: 2000},
-					},
+			backend: newTestBackend(nil, block{
+				full: true,
+				txs: []tx{
+					{price: 2000},
 				},
-			),
+			}),
 		},
 		{
 			name: "incomplete",
@@ -68,14 +63,12 @@ func TestOracle_SuggestPrice(t *testing.T) {
 				Blocks:     10,
 				Percentile: 60,
 			},
-			backend: newTestBackend(
-				block{
-					full: true,
-					txs: []tx{
-						{price: Default.Uint64() * 10},
-					},
+			backend: newTestBackend(nil, block{
+				full: true,
+				txs: []tx{
+					{price: Default.Uint64() * 10},
 				},
-			),
+			}),
 		},
 		{
 			name: "some full",
@@ -84,25 +77,19 @@ func TestOracle_SuggestPrice(t *testing.T) {
 				Blocks:     5,
 				Percentile: 60,
 			},
-			backend: newTestBackend(
-				block{
-					full: true,
-					txs:  []tx{{price: 10}},
-				},
-				block{
-					txs: []tx{{price: 1}},
-				},
-				block{
-					txs: []tx{{price: 5}},
-				},
-				block{
-					full: true,
-					txs:  []tx{{price: 7}},
-				},
-				block{
-					txs: []tx{{price: 20}},
-				},
-			),
+			backend: newTestBackend(nil, block{
+				full: true,
+				txs:  []tx{{price: 10}},
+			}, block{
+				txs: []tx{{price: 1}},
+			}, block{
+				txs: []tx{{price: 5}},
+			}, block{
+				full: true,
+				txs:  []tx{{price: 7}},
+			}, block{
+				txs: []tx{{price: 20}},
+			}),
 		},
 		{
 			name: "some full-100",
@@ -112,26 +99,20 @@ func TestOracle_SuggestPrice(t *testing.T) {
 				Percentile: 100,
 				Default:    bigInt(1),
 			},
-			backend: newTestBackend(
-				block{
-					full: true,
-					txs:  []tx{{price: 10}},
-				},
-				block{
-					txs: []tx{{price: 1}},
-				},
-				block{
-					txs: []tx{{price: 5}},
-				},
-				block{
-					full: true,
-					txs:  []tx{{price: 7}},
-				},
-				block{
-					full: true,
-					txs:  []tx{{price: 20}},
-				},
-			),
+			backend: newTestBackend(nil, block{
+				full: true,
+				txs:  []tx{{price: 10}},
+			}, block{
+				txs: []tx{{price: 1}},
+			}, block{
+				txs: []tx{{price: 5}},
+			}, block{
+				full: true,
+				txs:  []tx{{price: 7}},
+			}, block{
+				full: true,
+				txs:  []tx{{price: 20}},
+			}),
 		},
 		{
 			name: "all full",
@@ -139,29 +120,24 @@ func TestOracle_SuggestPrice(t *testing.T) {
 			params: Config{
 				Blocks:     5,
 				Percentile: 50,
+				Default:    bigInt(1),
 			},
-			backend: newTestBackend(
-				block{
-					full: true,
-					txs:  []tx{{price: 10}},
-				},
-				block{
-					full: true,
-					txs:  []tx{{price: 1}},
-				},
-				block{
-					full: true,
-					txs:  []tx{{price: 5}},
-				},
-				block{
-					full: true,
-					txs:  []tx{{price: 7}},
-				},
-				block{
-					full: true,
-					txs:  []tx{{price: 20}},
-				},
-			),
+			backend: newTestBackend(nil, block{
+				full: true,
+				txs:  []tx{{price: 10}},
+			}, block{
+				full: true,
+				txs:  []tx{{price: 1}},
+			}, block{
+				full: true,
+				txs:  []tx{{price: 5}},
+			}, block{
+				full: true,
+				txs:  []tx{{price: 7}},
+			}, block{
+				full: true,
+				txs:  []tx{{price: 20}},
+			}),
 		},
 		{
 			name: "some empty",
@@ -171,22 +147,16 @@ func TestOracle_SuggestPrice(t *testing.T) {
 				Percentile: 60,
 				Default:    bigInt(1),
 			},
-			backend: newTestBackend(
-				block{
-					full: true,
-					txs:  []tx{{price: 10}},
-				},
-				block{},
-				block{
-					full: true,
-					txs:  []tx{{price: 5}},
-				},
-				block{
-					full: true,
-					txs:  []tx{{price: 7}},
-				},
-				block{},
-			),
+			backend: newTestBackend(nil, block{
+				full: true,
+				txs:  []tx{{price: 10}},
+			}, block{}, block{
+				full: true,
+				txs:  []tx{{price: 5}},
+			}, block{
+				full: true,
+				txs:  []tx{{price: 7}},
+			}, block{}),
 		},
 		{
 			name: "all empty",
@@ -195,13 +165,7 @@ func TestOracle_SuggestPrice(t *testing.T) {
 				Blocks:     5,
 				Percentile: 50,
 			},
-			backend: newTestBackend(
-				block{},
-				block{},
-				block{},
-				block{},
-				block{},
-			),
+			backend: newTestBackend(nil, block{}, block{}, block{}, block{}, block{}),
 		},
 		{
 			name: "all full local",
@@ -211,27 +175,50 @@ func TestOracle_SuggestPrice(t *testing.T) {
 				Percentile: 50,
 				Default:    bigInt(1),
 			},
-			backend: newTestBackend(
-				block{
-					full: true,
-					txs:  []tx{{price: 10, local: true}},
-				},
-				block{
-					full: true,
-					txs:  []tx{{price: 50, local: true}},
-				},
-				block{
-					full: true,
-					txs:  []tx{{price: 5, local: true}},
-				},
-				block{
-					full: true,
-					txs:  []tx{{price: 7, local: true}},
-				},
-				block{
-					full: true,
-					txs:  []tx{{price: 20, local: true}},
-				},
+			backend: newTestBackend(nil, block{
+				full: true,
+				txs:  []tx{{price: 10, local: true}},
+			}, block{
+				full: true,
+				txs:  []tx{{price: 50, local: true}},
+			}, block{
+				full: true,
+				txs:  []tx{{price: 5, local: true}},
+			}, block{
+				full: true,
+				txs:  []tx{{price: 7, local: true}},
+			}, block{
+				full: true,
+				txs:  []tx{{price: 20, local: true}},
+			}),
+		},
+		{
+			name: "darvaza-before",
+			exp:  Default.Uint64(),
+			params: Config{
+				Blocks:     5,
+				Percentile: 50,
+				Default:    nil,
+			},
+			backend: newTestBackend(&params.ChainConfig{
+				DarvazaBlock:      big.NewInt(140000),
+				DarvazaDefaultGas: new(big.Int).Mul(Default, bigInt(2))},
+				block{},
+			),
+		},
+		{
+			name: "darvaza-after",
+			exp:  2 * Default.Uint64(),
+			params: Config{
+				Blocks:     5,
+				Percentile: 50,
+				Default:    nil,
+			},
+			backend: newTestBackend(&params.ChainConfig{
+				DarvazaBlock:      big.NewInt(14),
+				DarvazaDefaultGas: new(big.Int).Mul(Default, bigInt(2))},
+				block{},
+				block{},
 			),
 		},
 	} {
@@ -274,12 +261,15 @@ type tx struct {
 	local bool
 }
 
-func newTestBackend(blockSpec ...block) OracleBackend {
+func newTestBackend(config *params.ChainConfig, blockSpec ...block) OracleBackend {
+	tb := &testBackend{config: config}
+	if tb.config == nil {
+		tb.config = params.MainnetChainConfig
+	}
 	number := rand.Intn(1000)
 	localKey, _ := crypto.GenerateKey()
 	localAddr := crypto.PubkeyToAddress(localKey.PublicKey)
 	otherKey, _ := crypto.GenerateKey()
-	var blocks []*types.Block
 	for i, b := range blockSpec {
 		gasUsed := uint64(len(b.txs)) * params.TxGas
 		gasLimit := gasUsed
@@ -300,13 +290,12 @@ func newTestBackend(blockSpec ...block) OracleBackend {
 			}
 			txs = append(txs, transaction(0, tx.price, key))
 		}
-		blocks = append(blocks, types.NewBlock(header, txs, nil, nil))
+		tb.blocks = append(tb.blocks, types.NewBlock(header, txs, nil, nil))
 	}
-	return &testBackend{
-		config:     params.MainnetChainConfig,
-		lastHeader: blocks[len(blocks)-1].Header(),
-		blocks:     blocks,
+	if l := len(tb.blocks); l > 0 {
+		tb.lastHeader = tb.blocks[len(tb.blocks)-1].Header()
 	}
+	return tb
 }
 
 func (b *testBackend) ChainConfig() *params.ChainConfig {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -735,7 +735,7 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNr rpc.BlockNumb
 	if args.Gas != nil {
 		gas = uint64(*args.Gas)
 	}
-	gasPrice := gasprice.Default
+	gasPrice := gasprice.DefaultFn(b.ChainConfig())(header.Number)
 	if args.GasPrice != nil {
 		gasPrice = args.GasPrice.ToInt()
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -61,7 +61,8 @@ var (
 		ByzantiumBlock:      big.NewInt(0),
 		ConstantinopleBlock: big.NewInt(4081350),
 		PetersburgBlock:     nil,
-		DarvazaBlock:        nil,
+		DarvazaBlock:        nil, //TODO
+		DarvazaDefaultGas:   new(big.Int).SetUint64(2000 * Shannon),
 
 		Clique: DefaultCliqueConfig(),
 	}
@@ -103,6 +104,7 @@ type ChainConfig struct {
 	ConstantinopleBlock *big.Int `json:"constantinopleBlock,omitempty"` // Constantinople switch block (nil = no fork, 0 = already activated)
 	PetersburgBlock     *big.Int `json:"petersburgBlock,omitempty"`     // Petersburg switch block (nil = same as Constantinople)
 	DarvazaBlock        *big.Int `json:"darvazaBlock,omitempty"`        // Darvaza switch block (nil = no fork, 0 = already activated)
+	DarvazaDefaultGas   *big.Int `json:"darvazaDefaultGas,omitempty"`   // Darvaza default gas value (nil = no change)
 	EWASMBlock          *big.Int `json:"ewasmBlock,omitempty"`          // EWASM switch block (nil = no fork, 0 = already activated)
 
 	// Various consensus engines

--- a/params/config.go
+++ b/params/config.go
@@ -61,7 +61,7 @@ var (
 		ByzantiumBlock:      big.NewInt(0),
 		ConstantinopleBlock: big.NewInt(4081350),
 		PetersburgBlock:     nil,
-		DarvazaBlock:        nil, //TODO
+		DarvazaBlock:        big.NewInt(16811000),
 		DarvazaDefaultGas:   new(big.Int).SetUint64(2000 * Shannon),
 
 		Clique: DefaultCliqueConfig(),

--- a/params/config.go
+++ b/params/config.go
@@ -45,6 +45,7 @@ var (
 		ByzantiumBlock:      big.NewInt(0),
 		ConstantinopleBlock: big.NewInt(5100000),
 		PetersburgBlock:     nil,
+		DarvazaBlock:        nil,
 
 		Clique: DefaultCliqueConfig(),
 	}
@@ -60,6 +61,7 @@ var (
 		ByzantiumBlock:      big.NewInt(0),
 		ConstantinopleBlock: big.NewInt(4081350),
 		PetersburgBlock:     nil,
+		DarvazaBlock:        nil,
 
 		Clique: DefaultCliqueConfig(),
 	}
@@ -69,11 +71,13 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, DefaultCliqueConfig()}
+	AllCliqueProtocolChanges = &ChainConfig{ChainId: big.NewInt(1337), HomesteadBlock: big.NewInt(0),
+		EIP150Block: big.NewInt(0), EIP155Block: big.NewInt(0), EIP158Block: big.NewInt(0),
+		ByzantiumBlock: big.NewInt(0), ConstantinopleBlock: big.NewInt(0), Clique: DefaultCliqueConfig()}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0),
-		nil, nil, nil, nil,
-		DefaultCliqueConfig(),
+	TestChainConfig = &ChainConfig{ChainId: big.NewInt(1), HomesteadBlock: big.NewInt(0),
+		EIP150Block: big.NewInt(0), EIP155Block: big.NewInt(0), EIP158Block: big.NewInt(0),
+		ByzantiumBlock: big.NewInt(0), Clique: DefaultCliqueConfig(),
 	}
 	TestRules = TestChainConfig.Rules(new(big.Int))
 )
@@ -98,6 +102,7 @@ type ChainConfig struct {
 	ByzantiumBlock      *big.Int `json:"byzantiumBlock,omitempty"`      // Byzantium switch block (nil = no fork, 0 = already on byzantium)
 	ConstantinopleBlock *big.Int `json:"constantinopleBlock,omitempty"` // Constantinople switch block (nil = no fork, 0 = already activated)
 	PetersburgBlock     *big.Int `json:"petersburgBlock,omitempty"`     // Petersburg switch block (nil = same as Constantinople)
+	DarvazaBlock        *big.Int `json:"darvazaBlock,omitempty"`        // Darvaza switch block (nil = no fork, 0 = already activated)
 	EWASMBlock          *big.Int `json:"ewasmBlock,omitempty"`          // EWASM switch block (nil = no fork, 0 = already activated)
 
 	// Various consensus engines
@@ -135,7 +140,8 @@ func (c *ChainConfig) String() string {
 	default:
 		engine = "unknown"
 	}
-	return fmt.Sprintf("{ChainID: %v Homestead: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v ConstantinopleFix: %v EWASM: %v Engine: %v}",
+	return fmt.Sprintf("{ChainID: %v Homestead: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople:"+
+		" %v ConstantinopleFix: %v Darvaza: %v EWASM: %v Engine: %v}",
 		c.ChainId,
 		c.HomesteadBlock,
 		c.EIP150Block,
@@ -144,6 +150,7 @@ func (c *ChainConfig) String() string {
 		c.ByzantiumBlock,
 		c.ConstantinopleBlock,
 		c.PetersburgBlock,
+		c.DarvazaBlock,
 		c.EWASMBlock,
 		engine,
 	)
@@ -184,6 +191,11 @@ func (c *ChainConfig) IsConstantinople(num *big.Int) bool {
 // - OR is nil, and Constantinople is active
 func (c *ChainConfig) IsPetersburg(num *big.Int) bool {
 	return isForked(c.PetersburgBlock, num) || c.PetersburgBlock == nil && isForked(c.ConstantinopleBlock, num)
+}
+
+// IsDarvaza returns whether num is either equal to the Darvaza fork block or greater.
+func (c *ChainConfig) IsDarvaza(num *big.Int) bool {
+	return isForked(c.DarvazaBlock, num)
 }
 
 // IsEWASM returns whether num represents a block number after the EWASM fork
@@ -252,6 +264,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	}
 	if isForkIncompatible(c.PetersburgBlock, newcfg.PetersburgBlock, head) {
 		return newCompatError("ConstantinopleFix fork block", c.PetersburgBlock, newcfg.PetersburgBlock)
+	}
+	if isForkIncompatible(c.DarvazaBlock, newcfg.DarvazaBlock, head) {
+		return newCompatError("Darvaza fork block", c.DarvazaBlock, newcfg.DarvazaBlock)
 	}
 	if isForkIncompatible(c.EWASMBlock, newcfg.EWASMBlock, head) {
 		return newCompatError("ewasm fork block", c.EWASMBlock, newcfg.EWASMBlock)

--- a/params/version.go
+++ b/params/version.go
@@ -1,7 +1,7 @@
 package params
 
 const (
-	Version = "3.3.9"
+	Version = "3.4.0"
 )
 
 func VersionWithCommit(gitCommit string) string {


### PR DESCRIPTION
This PR prepares for gochain/gips/issues/30 by adding a fork block switch to burn all gas fees instead of sending them to the signer of the block, and to reconfigure the gas price for gochain/gips/issues/29 at the same time.

### Todo
- [ ] ~adapt `TotalSupply` to account for the burned fees~
- [x] set testnet fork block number

#### GIP-29 Auto Config

Automatically reconfigure gas price parameters for GIP-29, at or around the Darvaza block.

- [x] block min - increase effective with darvaza block
- [x] tx pool min - increase effective with darvaza block (a case could be made for delaying this increase so that underpriced txs don't 'disappear' from the tx pool, but they need to be resubmitted with a higher price either way and leaving them pending might suggest they could still process)
- [x] gas oracle min - increase just before the darvaza block, to reduce chance of underpriced tx requiring resubmit